### PR TITLE
22 move appview properties from bottom into properties window

### DIFF
--- a/src/UICrafter.Client/Components/AppViewDesigner.razor
+++ b/src/UICrafter.Client/Components/AppViewDesigner.razor
@@ -2,7 +2,7 @@
 
 <MudContainer MaxWidth="MaxWidth.Small" @onclick:stopPropagation>
     <MudDropContainer T="UIComponent" @ref="DropContainer" Items="UIComponents" ItemsSelector="@((item,dropzone) => item.DropZoneID == dropzone)" ItemDropped="ComponentUpdated" Class="d-flex flex-grow-1">
-        <ChildContent >
+        <ChildContent>
             <MudDropZone T="UIComponent" Identifier="Drop Zone 1" AllowReorder="true" Class="rounded mud-background-gray pa-2 flex-grow-1 overflow-auto" Style="height: 70vh">
             </MudDropZone>
         </ChildContent>
@@ -17,7 +17,7 @@
             }
             else if (context.ComponentCase == UIComponent.ComponentOneofCase.Textbox)
             {
-                <DragDropTextBox UIComponent="context" OnSelect="SelectComponent"/>
+                <DragDropTextBox UIComponent="context" OnSelect="SelectComponent" />
             }
             else
             {
@@ -55,7 +55,7 @@
         get => _internalDropContainer;
         set
         {
-            if(DropContainerChanged.HasDelegate && value != _internalDropContainer)
+            if (DropContainerChanged.HasDelegate && value != _internalDropContainer)
             {
                 _internalDropContainer = value;
                 DropContainerChanged.InvokeAsync(value);
@@ -65,7 +65,13 @@
     [Parameter]
     public required EventCallback<MudDropContainer<UIComponent>?> DropContainerChanged { get; set; }
 
-    private void SelectComponent(UIComponent component) => SelectedComponent = component;
+    private void SelectComponent(UIComponent component)
+    {
+        if (SelectedComponent == component) return;
+
+        SelectedComponent = component;
+        DropContainer?.Refresh();
+    }
 
     private void ComponentUpdated(MudItemDropInfo<UIComponent> component)
     {

--- a/src/UICrafter.Client/Components/AppViewDesigner.razor
+++ b/src/UICrafter.Client/Components/AppViewDesigner.razor
@@ -1,6 +1,6 @@
 @using UICrafter.Client.Components.DnDComponents
 
-<MudContainer MaxWidth="MaxWidth.Small" @onclick:stopPropagation Style="background-color: red;">
+<MudContainer MaxWidth="MaxWidth.Small" @onclick:stopPropagation>
     <MudDropContainer T="UIComponent" @ref="DropContainer" Items="UIComponents" ItemsSelector="@((item,dropzone) => item.DropZoneID == dropzone)" ItemDropped="ComponentUpdated" Class="d-flex flex-grow-1">
         <ChildContent >
             <MudDropZone T="UIComponent" Identifier="Drop Zone 1" AllowReorder="true" Class="rounded mud-background-gray pa-2 flex-grow-1 overflow-auto" Style="height: 70vh">

--- a/src/UICrafter.Client/Components/AppViewDesigner.razor
+++ b/src/UICrafter.Client/Components/AppViewDesigner.razor
@@ -1,8 +1,8 @@
 @using UICrafter.Client.Components.DnDComponents
 
-<MudContainer MaxWidth="MaxWidth.Small">
+<MudContainer MaxWidth="MaxWidth.Small" @onclick:stopPropagation Style="background-color: red;">
     <MudDropContainer T="UIComponent" @ref="DropContainer" Items="UIComponents" ItemsSelector="@((item,dropzone) => item.DropZoneID == dropzone)" ItemDropped="ComponentUpdated" Class="d-flex flex-grow-1">
-        <ChildContent>
+        <ChildContent >
             <MudDropZone T="UIComponent" Identifier="Drop Zone 1" AllowReorder="true" Class="rounded mud-background-gray pa-2 flex-grow-1 overflow-auto" Style="height: 70vh">
             </MudDropZone>
         </ChildContent>

--- a/src/UICrafter.Client/Components/AppViewProperties.razor
+++ b/src/UICrafter.Client/Components/AppViewProperties.razor
@@ -1,38 +1,45 @@
-<MudStack Row="true">
-    <MudOverlay Visible="Visible" DarkBackground="true" Absolute="true">
-        <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-    </MudOverlay>
+<MudStack>
+    @if (AppView is not null)
+    {
+        <MudOverlay Visible="Visible" DarkBackground="true" Absolute="true">
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        </MudOverlay>
 
-    <MudTextField @bind-Value="@AppView.Name" Label="App-view name" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField @bind-Value="@AppView.Name" Label="App-view name" Variant="Variant.Outlined"></MudTextField>
 
-    <MudButtonGroup Variant="Variant.Outlined" Class="uicrafter-tooltip-buttongroup ma-2">
-        <MudTooltip Text="Public" Arrow="true" Placement="Placement.Bottom" Class="uicrafter-tooltip-buttongroup">
-            <MudToggleIconButton @bind-Toggled="AppView.IsPublic" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.PublicOff" ToggledIcon="@Icons.Material.Filled.Public" />
-        </MudTooltip>
-        <MudTooltip Text="Save" Arrow="true" Placement="Placement.Bottom">
-            <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick="@SaveAppView" />
-        </MudTooltip>
-        <MudTooltip Text="Delete" Arrow="true" Placement="Placement.Bottom">
-            <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@DeleteAppView" />
-        </MudTooltip>
-        <MudTooltip Text="Clear" Arrow="true" Placement="Placement.Bottom">
-            <MudIconButton Icon="@Icons.Material.Filled.Clear" OnClick="@ClearAppView" />
-        </MudTooltip>
-        <MudTooltip Text="Load" Arrow="true" Placement="Placement.Bottom">
-            <MudIconButton Icon="@Icons.Material.Filled.Download" OnClick="@LoadAppView" />
-        </MudTooltip>
-    </MudButtonGroup>
+        @if (AppView.CreatedAt != DateTime.MinValue && AppView.UpdatedAt != DateTime.MinValue)
+        {
+            <MudDatePicker Date="@AppView.CreatedAt" Label="Created at" Variant="Variant.Outlined" ReadOnly="true" />
+            <MudDatePicker Date="@AppView.UpdatedAt" Label="Created at" Variant="Variant.Outlined" ReadOnly="true" />
+        }
+
+        <MudSwitch @bind-Value="AppView.IsPublic" Class="uicrafter-switch" Label="Public" ThumbIcon="@(AppView.IsPublic ? Icons.Material.Filled.Public : Icons.Material.Filled.PublicOff)" LabelPosition="LabelPosition.Start" />
+
+        <MudButtonGroup Variant="Variant.Outlined" Class="uicrafter-tooltip-buttongroup justify-center ma-2">
+            <MudTooltip Text="Save" Arrow="true" Placement="Placement.Bottom">
+                <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick="@SaveAppView" />
+            </MudTooltip>
+            <MudTooltip Text="Delete" Arrow="true" Placement="Placement.Bottom">
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@DeleteAppView" />
+            </MudTooltip>
+            <MudTooltip Text="Clear" Arrow="true" Placement="Placement.Bottom">
+                <MudIconButton Icon="@Icons.Material.Filled.Clear" OnClick="@ClearAppView" />
+            </MudTooltip>
+            <MudTooltip Text="Load" Arrow="true" Placement="Placement.Bottom">
+                <MudIconButton Icon="@Icons.Material.Filled.Download" OnClick="@LoadAppView" />
+            </MudTooltip>
+        </MudButtonGroup>
+    }
 </MudStack>
 
 @code {
     [Inject]
     private IAppViewRepository AppViewRepository { get; set; } = default!;
 
-    private AppView AppView { get; set; } = new AppView { Name = string.Empty };
     private bool Visible { get; set; } = false;
 
     [Parameter]
-    public required UIComponentList UIComponentList { get; set; }
+    public required RepeatedField<UIComponent> UIComponents { get; set; }
 
     private UIComponent? _internalSelectedComponent;
     [Parameter]
@@ -68,13 +75,30 @@
     [Parameter]
     public required EventCallback<MudDropContainer<UIComponent>?> DropContainerChanged { get; set; }
 
-    AppView test = new AppView();
+    private AppView? _internalAppView;
+    [Parameter]
+    public required AppView? AppView
+    {
+        get => _internalAppView;
+        set
+        {
+            if (AppViewChanged.HasDelegate && value != _internalAppView)
+            {
+                _internalAppView = value;
+                AppViewChanged.InvokeAsync(value);
+            }
+        }
+    }
+    [Parameter]
+    public required EventCallback<AppView?> AppViewChanged { get; set; }
 
     private async Task SaveAppView()
     {
+        if (AppView is null) return;
+
         Visible = true;
 
-        var serializedContent = UIComponentList.ToByteString();
+        var serializedContent = new UIComponentList { UIComponents = { UIComponents } }.ToByteString();
 
         AppView.Content = serializedContent;
 
@@ -101,6 +125,8 @@
 
     private async Task DeleteAppView()
     {
+        if (AppView is null) return;
+
         Visible = true;
 
         try
@@ -124,18 +150,18 @@
 
     private void ClearAppView()
     {
-        if (UIComponentList.UIComponents.Count == 0) return;
+        if (UIComponents.Count == 0) return;
 
-        UIComponentList.UIComponents.Clear();
+        UIComponents.Clear();
         SelectedComponent = null;
         DropContainer?.Refresh();
     }
 
     private async Task LoadAppView()
     {
-        Visible = true;
+        if (AppView is null) return;
 
-        ClearAppView();
+        Visible = true;
 
         try
         {
@@ -145,9 +171,11 @@
 
             AppView = await AppViewRepository.GetAppViewById(id);
 
+            ClearAppView();
+
             var parsedContent = UIComponentList.Parser.ParseFrom(AppView.Content);
 
-            UIComponentList.UIComponents.AddRange(parsedContent.UIComponents);
+            UIComponents.AddRange(parsedContent.UIComponents);
 
             DropContainer?.Refresh();
         }

--- a/src/UICrafter.Client/Components/AppViewProperties.razor
+++ b/src/UICrafter.Client/Components/AppViewProperties.razor
@@ -1,36 +1,34 @@
-<MudStack>
-    @if (AppView is not null)
+@if (AppView is not null)
+{
+    <MudOverlay Visible="Visible" DarkBackground="true" Absolute="true">
+        <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+    </MudOverlay>
+
+    <MudTextField @bind-Value="@AppView.Name" Label="App-view name" Variant="Variant.Outlined"></MudTextField>
+
+    @if (AppView.CreatedAt != DateTime.MinValue && AppView.UpdatedAt != DateTime.MinValue)
     {
-        <MudOverlay Visible="Visible" DarkBackground="true" Absolute="true">
-            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-        </MudOverlay>
-
-        <MudTextField @bind-Value="@AppView.Name" Label="App-view name" Variant="Variant.Outlined"></MudTextField>
-
-        @if (AppView.CreatedAt != DateTime.MinValue && AppView.UpdatedAt != DateTime.MinValue)
-        {
-            <MudDatePicker Date="@AppView.CreatedAt" Label="Created at" Variant="Variant.Outlined" ReadOnly="true" />
-            <MudDatePicker Date="@AppView.UpdatedAt" Label="Created at" Variant="Variant.Outlined" ReadOnly="true" />
-        }
-
-        <MudSwitch @bind-Value="AppView.IsPublic" Class="uicrafter-switch" Label="Public" ThumbIcon="@(AppView.IsPublic ? Icons.Material.Filled.Public : Icons.Material.Filled.PublicOff)" LabelPosition="LabelPosition.Start" />
-
-        <MudButtonGroup Variant="Variant.Outlined" Class="uicrafter-tooltip-buttongroup justify-center ma-2">
-            <MudTooltip Text="Save" Arrow="true" Placement="Placement.Bottom">
-                <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick="@SaveAppView" />
-            </MudTooltip>
-            <MudTooltip Text="Delete" Arrow="true" Placement="Placement.Bottom">
-                <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@DeleteAppView" />
-            </MudTooltip>
-            <MudTooltip Text="Clear" Arrow="true" Placement="Placement.Bottom">
-                <MudIconButton Icon="@Icons.Material.Filled.Clear" OnClick="@ClearAppView" />
-            </MudTooltip>
-            <MudTooltip Text="Load" Arrow="true" Placement="Placement.Bottom">
-                <MudIconButton Icon="@Icons.Material.Filled.Download" OnClick="@LoadAppView" />
-            </MudTooltip>
-        </MudButtonGroup>
+        <MudDatePicker Date="@AppView.CreatedAt" Label="Created at" Variant="Variant.Outlined" ReadOnly />
+        <MudDatePicker Date="@AppView.UpdatedAt" Label="Created at" Variant="Variant.Outlined" ReadOnly />
     }
-</MudStack>
+
+    <MudSwitch @bind-Value="AppView.IsPublic" Class="uicrafter-switch" Label="Public" ThumbIcon="@(AppView.IsPublic ? Icons.Material.Filled.Public : Icons.Material.Filled.PublicOff)" LabelPosition="LabelPosition.Start" />
+
+    <MudButtonGroup Variant="Variant.Outlined" Class="uicrafter-tooltip-buttongroup justify-center ma-2">
+        <MudTooltip Text="Save" Arrow Placement="Placement.Bottom">
+            <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick="@SaveAppView" />
+        </MudTooltip>
+        <MudTooltip Text="Delete" Arrow Placement="Placement.Bottom">
+            <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@DeleteAppView" />
+        </MudTooltip>
+        <MudTooltip Text="Clear" Arrow Placement="Placement.Bottom">
+            <MudIconButton Icon="@Icons.Material.Filled.Clear" OnClick="@ClearAppView" />
+        </MudTooltip>
+        <MudTooltip Text="Load" Arrow Placement="Placement.Bottom">
+            <MudIconButton Icon="@Icons.Material.Filled.Download" OnClick="@LoadAppView" />
+        </MudTooltip>
+    </MudButtonGroup>
+}
 
 @code {
     [Inject]

--- a/src/UICrafter.Client/Components/ComponentGrid.razor
+++ b/src/UICrafter.Client/Components/ComponentGrid.razor
@@ -1,25 +1,21 @@
-<MudStack>
-    <MudText Class="">Components:</MudText>
+<MudContainer Class="rounded mud-background-gray pa-4" @onclick:stopPropagation>
+    <MudGrid>
+        <MudItem sm="12" lg="4" Class="d-flex flex-column justify-start align-center">
+            <MudIconButton Icon="@Icons.Material.Filled.SmartButton" Variant="Variant.Outlined" OnClick=@AddNewButton Size="Size.Large" />
+            <MudText>API-Button</MudText>
+        </MudItem>
 
-    <MudContainer Class="rounded mud-background-gray pa-4">
-        <MudGrid>
-            <MudItem sm="12" lg="4" Class="d-flex flex-column justify-start align-center">
-                <MudIconButton Icon="@Icons.Material.Filled.SmartButton" Variant="Variant.Outlined" OnClick=@AddNewButton Size="Size.Large" />
-                <MudText>API-Button</MudText>
-            </MudItem>
+        <MudItem sm="12" lg="4" Class="d-flex flex-column justify-start align-center">
+            <MudIconButton Icon="@Icons.Material.Filled.TextFields" Variant="Variant.Outlined" OnClick=@AddNewTextbox Size="Size.Large" />
+            <MudText>Textbox</MudText>
+        </MudItem>
 
-            <MudItem sm="12" lg="4" Class="d-flex flex-column justify-start align-center">
-                <MudIconButton Icon="@Icons.Material.Filled.TextFields" Variant="Variant.Outlined" OnClick=@AddNewTextbox Size="Size.Large" />
-                <MudText>Textbox</MudText>
-            </MudItem>
-
-            <MudItem sm="12" lg="4" Class="d-flex flex-column justify-start align-center">
-                <MudIconButton Icon="@Icons.Material.Filled.Input" Variant="Variant.Outlined" OnClick=@AddNewInputField Size="Size.Large" />
-                <MudText>Input</MudText>
-            </MudItem>
-        </MudGrid>
-    </MudContainer>
-</MudStack>
+        <MudItem sm="12" lg="4" Class="d-flex flex-column justify-start align-center">
+            <MudIconButton Icon="@Icons.Material.Filled.Input" Variant="Variant.Outlined" OnClick=@AddNewInputField Size="Size.Large" />
+            <MudText>Input</MudText>
+        </MudItem>
+    </MudGrid>
+</MudContainer>
 
 @code {
     [Parameter]

--- a/src/UICrafter.Client/Components/ComponentGrid.razor
+++ b/src/UICrafter.Client/Components/ComponentGrid.razor
@@ -1,4 +1,4 @@
-<MudStack Style="width: 20%">
+<MudStack>
     <MudText Class="">Components:</MudText>
 
     <MudContainer Class="rounded mud-background-gray pa-4">

--- a/src/UICrafter.Client/Components/ComponentProperties.razor
+++ b/src/UICrafter.Client/Components/ComponentProperties.razor
@@ -1,38 +1,31 @@
-<MudStack Class="rounded mud-background-gray pa-4 my-2 ">
-    @if (SelectedComponent is not null)
+<MudStack>
+    @if(SelectedComponent is not null)
+    @if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Button)
     {
-        @if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Button)
-        {
-            <MudTextField @bind-Value="SelectedComponent.Button.Label" Label="Button Label" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
-            <MudTextField @bind-Value="SelectedComponent.Button.URL" Label="Button URL" Variant="Variant.Outlined"></MudTextField>
-        }
-        else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.InputField)
-        {
-            <MudTextField @bind-Value="SelectedComponent.InputField.Label" Label="Input Placeholder" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
-        }
-        else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Textbox)
-        {
-            <MudTextField @bind-Value="SelectedComponent.Textbox.Label" Label="Textbox label" Variant="Variant.Outlined"></MudTextField>
-            <MudTextField @bind-Value="SelectedComponent.Textbox.NumberOfLines" Label="Number of lines" Variant="Variant.Outlined"></MudTextField>
-            <MudTextField @bind-Value="SelectedComponent.Textbox.Content" Label="Textbox Content" Variant="Variant.Outlined" Lines="4"></MudTextField>
-            <MudSelect T="string" Label="Source Reference" @bind-Value="SelectedComponent.Textbox.SourceRef">
-                <MudSelectItem Value="Guid.Empty.ToString()">None</MudSelectItem>
-                @foreach (var component in UIComponents.Where(c => c.ComponentCase == UIComponent.ComponentOneofCase.Button))
-                {
-                    <MudSelectItem Value="@component.Guid">@component.Button.Label</MudSelectItem>
-                }
-            </MudSelect>
-            <MudTextField @bind-Value="SelectedComponent.Textbox.JsonField" Label="Json Field" Variant="Variant.Outlined"></MudTextField>
-        }
-        <MudButtonGroup Variant="Variant.Outlined" Class="mx-auto">
-            <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick=@SaveSelectedComponent Size="Size.Large" />
-            <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick=@DeleteSelectedComponent Size="Size.Large" />
-        </MudButtonGroup>
+        <MudTextField @bind-Value="SelectedComponent.Button.Label" Label="Button Label" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
+        <MudTextField @bind-Value="SelectedComponent.Button.URL" Label="Button URL" Variant="Variant.Outlined"></MudTextField>
     }
-    else
+    else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.InputField)
     {
-        <MudText>AppView properties and buttons</MudText>
+        <MudTextField @bind-Value="SelectedComponent.InputField.Label" Label="Input Placeholder" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
     }
+    else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Textbox)
+    {
+        <MudTextField @bind-Value="SelectedComponent.Textbox.Label" Label="Textbox label" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField @bind-Value="SelectedComponent.Textbox.NumberOfLines" Label="Number of lines" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField @bind-Value="SelectedComponent.Textbox.Content" Label="Textbox Content" Variant="Variant.Outlined" Lines="4"></MudTextField>
+        <MudSelect T="string" Label="Source Reference" @bind-Value="SelectedComponent.Textbox.SourceRef">
+            <MudSelectItem Value="Guid.Empty.ToString()">None</MudSelectItem>
+            @foreach (var component in UIComponents.Where(c => c.ComponentCase == UIComponent.ComponentOneofCase.Button))
+            {
+                <MudSelectItem Value="@component.Guid">@component.Button.Label</MudSelectItem>
+            }
+        </MudSelect>
+        <MudTextField @bind-Value="SelectedComponent.Textbox.JsonField" Label="Json Field" Variant="Variant.Outlined"></MudTextField>
+    }
+    <MudButtonGroup Variant="Variant.Outlined" Class="mx-auto">
+        <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick=@DeleteSelectedComponent Size="Size.Large">Delete</MudButton>
+    </MudButtonGroup>
 </MudStack>
 
 @code {

--- a/src/UICrafter.Client/Components/ComponentProperties.razor
+++ b/src/UICrafter.Client/Components/ComponentProperties.razor
@@ -1,5 +1,5 @@
-<MudStack>
-    @if(SelectedComponent is not null)
+@if (SelectedComponent is not null)
+{
     @if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Button)
     {
         <MudTextField @bind-Value="SelectedComponent.Button.Label" Label="Button Label" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
@@ -26,7 +26,7 @@
     <MudButtonGroup Variant="Variant.Outlined" Class="mx-auto">
         <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick=@DeleteSelectedComponent Size="Size.Large">Delete</MudButton>
     </MudButtonGroup>
-</MudStack>
+}
 
 @code {
     [Parameter]

--- a/src/UICrafter.Client/Components/ComponentProperties.razor
+++ b/src/UICrafter.Client/Components/ComponentProperties.razor
@@ -1,42 +1,38 @@
-<MudStack Style="width: 25%;">
-    <MudText>Properties:</MudText>
-
-    <MudStack Class="rounded mud-background-gray pa-4 my-2 ">
-        @if (SelectedComponent is not null)
+<MudStack Class="rounded mud-background-gray pa-4 my-2 ">
+    @if (SelectedComponent is not null)
+    {
+        @if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Button)
         {
-            @if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Button)
-            {
-                <MudTextField @bind-Value="SelectedComponent.Button.Label" Label="Button Label" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
-                <MudTextField @bind-Value="SelectedComponent.Button.URL" Label="Button URL" Variant="Variant.Outlined"></MudTextField>
-            }
-            else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.InputField)
-            {
-                <MudTextField @bind-Value="SelectedComponent.InputField.Label" Label="Input Placeholder" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
-            }
-            else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Textbox)
-            {
-                <MudTextField @bind-Value="SelectedComponent.Textbox.Label" Label="Textbox label" Variant="Variant.Outlined"></MudTextField>
-                <MudTextField @bind-Value="SelectedComponent.Textbox.NumberOfLines" Label="Number of lines" Variant="Variant.Outlined"></MudTextField>
-                <MudTextField @bind-Value="SelectedComponent.Textbox.Content" Label="Textbox Content" Variant="Variant.Outlined" Lines="4"></MudTextField>
-                <MudSelect T="string" Label="Source Reference" @bind-Value="SelectedComponent.Textbox.SourceRef">
-                    <MudSelectItem Value="Guid.Empty.ToString()">None</MudSelectItem>
-                    @foreach (var component in UIComponents.Where(c => c.ComponentCase == UIComponent.ComponentOneofCase.Button))
-                    {
-                        <MudSelectItem Value="@component.Guid">@component.Button.Label</MudSelectItem>
-                    }
-                </MudSelect>
-                <MudTextField @bind-Value="SelectedComponent.Textbox.JsonField" Label="Json Field" Variant="Variant.Outlined"></MudTextField>
-            }
-            <MudButtonGroup Variant="Variant.Outlined" Class="mx-auto">
-                <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick=@SaveSelectedComponent Size="Size.Large" />
-                <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick=@DeleteSelectedComponent Size="Size.Large" />
-            </MudButtonGroup>
+            <MudTextField @bind-Value="SelectedComponent.Button.Label" Label="Button Label" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
+            <MudTextField @bind-Value="SelectedComponent.Button.URL" Label="Button URL" Variant="Variant.Outlined"></MudTextField>
         }
-        else
+        else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.InputField)
         {
-            <MudText Typo="Typo.body1">No component selected.</MudText>
+            <MudTextField @bind-Value="SelectedComponent.InputField.Label" Label="Input Placeholder" Variant="Variant.Outlined" MaxLength="25"></MudTextField>
         }
-    </MudStack>
+        else if (SelectedComponent.ComponentCase == UIComponent.ComponentOneofCase.Textbox)
+        {
+            <MudTextField @bind-Value="SelectedComponent.Textbox.Label" Label="Textbox label" Variant="Variant.Outlined"></MudTextField>
+            <MudTextField @bind-Value="SelectedComponent.Textbox.NumberOfLines" Label="Number of lines" Variant="Variant.Outlined"></MudTextField>
+            <MudTextField @bind-Value="SelectedComponent.Textbox.Content" Label="Textbox Content" Variant="Variant.Outlined" Lines="4"></MudTextField>
+            <MudSelect T="string" Label="Source Reference" @bind-Value="SelectedComponent.Textbox.SourceRef">
+                <MudSelectItem Value="Guid.Empty.ToString()">None</MudSelectItem>
+                @foreach (var component in UIComponents.Where(c => c.ComponentCase == UIComponent.ComponentOneofCase.Button))
+                {
+                    <MudSelectItem Value="@component.Guid">@component.Button.Label</MudSelectItem>
+                }
+            </MudSelect>
+            <MudTextField @bind-Value="SelectedComponent.Textbox.JsonField" Label="Json Field" Variant="Variant.Outlined"></MudTextField>
+        }
+        <MudButtonGroup Variant="Variant.Outlined" Class="mx-auto">
+            <MudIconButton Icon="@Icons.Material.Filled.Save" OnClick=@SaveSelectedComponent Size="Size.Large" />
+            <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick=@DeleteSelectedComponent Size="Size.Large" />
+        </MudButtonGroup>
+    }
+    else
+    {
+        <MudText Typo="Typo.body1">No component selected.</MudText>
+    }
 </MudStack>
 
 @code {

--- a/src/UICrafter.Client/Components/ComponentProperties.razor
+++ b/src/UICrafter.Client/Components/ComponentProperties.razor
@@ -31,7 +31,7 @@
     }
     else
     {
-        <MudText Typo="Typo.body1">No component selected.</MudText>
+        <MudText>AppView properties and buttons</MudText>
     }
 </MudStack>
 

--- a/src/UICrafter.Client/Components/Properties.razor
+++ b/src/UICrafter.Client/Components/Properties.razor
@@ -1,4 +1,4 @@
-<MudStack Class="rounded mud-background-gray pa-4 my-2 " @onclick:stopPropagation>
+<MudStack Class="rounded mud-background-gray pa-4 " @onclick:stopPropagation>
     @if (SelectedComponent is not null)
     {
         <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponents" />

--- a/src/UICrafter.Client/Components/Properties.razor
+++ b/src/UICrafter.Client/Components/Properties.razor
@@ -1,0 +1,66 @@
+<MudStack Class="rounded mud-background-gray pa-4 my-2 " @onclick:stopPropagation>
+    @if (SelectedComponent is not null)
+    {
+        <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponents" />
+    }
+    else
+    {
+        <AppViewProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponents" @bind-AppView="AppView" />
+    }
+</MudStack>
+
+@code {
+    [Parameter]
+    public required RepeatedField<UIComponent> UIComponents { get; set; }
+
+    private UIComponent? _internalSelectedComponent;
+    [Parameter]
+    public required UIComponent? SelectedComponent
+    {
+        get => _internalSelectedComponent;
+        set
+        {
+            if (SelectedComponentChanged.HasDelegate && value != _internalSelectedComponent)
+            {
+                _internalSelectedComponent = value;
+                SelectedComponentChanged.InvokeAsync(value);
+            }
+        }
+    }
+    [Parameter]
+    public required EventCallback<UIComponent?> SelectedComponentChanged { get; set; }
+
+    private MudDropContainer<UIComponent>? _internalDropContainer;
+    [Parameter]
+    public required MudDropContainer<UIComponent>? DropContainer
+    {
+        get => _internalDropContainer;
+        set
+        {
+            if (DropContainerChanged.HasDelegate && value != _internalDropContainer)
+            {
+                _internalDropContainer = value;
+                DropContainerChanged.InvokeAsync(value);
+            }
+        }
+    }
+    [Parameter]
+    public required EventCallback<MudDropContainer<UIComponent>?> DropContainerChanged { get; set; }
+
+    private AppView? _internalAppView;
+    [Parameter]
+    public required AppView? AppView
+    {
+        get => _internalAppView;
+        set
+        {
+            if (AppViewChanged.HasDelegate && value != _internalAppView)
+            {
+                _internalAppView = value;
+                AppViewChanged.InvokeAsync(value);
+            }
+        }
+    }
+    [Parameter]
+    public required EventCallback<AppView?> AppViewChanged { get; set; }
+}

--- a/src/UICrafter.Client/Pages/UICrafterPage.razor
+++ b/src/UICrafter.Client/Pages/UICrafterPage.razor
@@ -4,7 +4,7 @@
 <MudStack Row @onclick="OnBackgroundClick" Style="height: 100vh;">
     <!-- Left section: Component Grid (20%) -->
     <MudStack Style="width: 20%">
-        <MudText Class="">Components:</MudText>
+        <MudText>Components:</MudText>
         <ComponentGrid @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
     </MudStack>
 
@@ -20,7 +20,7 @@
             <MudText>@($"{CurrentPropertiesName()} properties:")</MudText>
             @if (SelectedComponent is not null)
             {
-                <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="() => {SelectedComponent = null;}" Class="ml-auto mud-background-gray" Size="Size.Small" Variant="Variant.Filled"/>
+                <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="() => {SelectedComponent = null;}" Class="ml-auto my-n1 mud-background-gray" Size="Size.Small" Variant="Variant.Filled"/>
             }
         </MudStack>
         <Properties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" @bind-AppView="AppView"/>

--- a/src/UICrafter.Client/Pages/UICrafterPage.razor
+++ b/src/UICrafter.Client/Pages/UICrafterPage.razor
@@ -1,25 +1,23 @@
 @page "/uicrafter"
 @attribute [Authorize]
 
-<MudStack Row="true" @onclick="kek">
+<MudStack Row="true" @onclick="OnBackgroundClick" Style="height: 100vh;">
     <!-- Left section: Component Grid (20%) -->
     <MudStack Style="width: 20%">
+        <MudText Class="">Components:</MudText>
         <ComponentGrid @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
     </MudStack>
 
     <!-- Center section: Dropzone (55%) -->
     <MudStack Style="width: 55%;" Class="align-center">
         <MudText>App-view:</MudText>
-
         <AppViewDesigner @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
-
-        <AppViewButtons @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponentList="@UIComponentList" />
     </MudStack>
 
     <!-- Right section: Component Properties (25%) -->
-    <MudStack Style="width: 25%;" @onclick:stopPropagation>
+    <MudStack Style="width: 25%;">
         <MudText>Properties:</MudText>
-        <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
+        <Properties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" @bind-AppView="AppView"/>
     </MudStack>
 </MudStack>
 
@@ -28,10 +26,13 @@
     private UIComponent? SelectedComponent { get; set; }
     private MudDropContainer<UIComponent>? DropContainer { get; set; }
     private UIComponentList UIComponentList { get; set; } = new UIComponentList();
+    private AppView AppView { get; set; } = new AppView { Name = string.Empty };
 
-    private void kek()
+    private void OnBackgroundClick()
     {
-        if (SelectedComponent is not null)
-            SelectedComponent = null;
+        if (SelectedComponent is null) return;
+
+        SelectedComponent = null;
+        DropContainer?.Refresh();
     }
 }

--- a/src/UICrafter.Client/Pages/UICrafterPage.razor
+++ b/src/UICrafter.Client/Pages/UICrafterPage.razor
@@ -1,9 +1,11 @@
 @page "/uicrafter"
 @attribute [Authorize]
 
-<MudStack Row="true" @onclick="() => {SelectedComponent = null;}">
+<MudStack Row="true" @onclick="kek">
     <!-- Left section: Component Grid (20%) -->
-    <ComponentGrid @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
+    <MudStack Style="width: 20%">
+        <ComponentGrid @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
+    </MudStack>
 
     <!-- Center section: Dropzone (55%) -->
     <MudStack Style="width: 55%;" Class="align-center">
@@ -17,15 +19,7 @@
     <!-- Right section: Component Properties (25%) -->
     <MudStack Style="width: 25%;" @onclick:stopPropagation>
         <MudText>Properties:</MudText>
-        @if (SelectedComponent is not null)
-        {
-            <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
-        }
-        else
-        {
-            <MudText>AppView properties and buttons</MudText>
-            @* <AppViewButtons @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponentList="@UIComponentList" /> *@
-        }
+        <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
     </MudStack>
 </MudStack>
 
@@ -34,4 +28,10 @@
     private UIComponent? SelectedComponent { get; set; }
     private MudDropContainer<UIComponent>? DropContainer { get; set; }
     private UIComponentList UIComponentList { get; set; } = new UIComponentList();
+
+    private void kek()
+    {
+        if (SelectedComponent is not null)
+            SelectedComponent = null;
+    }
 }

--- a/src/UICrafter.Client/Pages/UICrafterPage.razor
+++ b/src/UICrafter.Client/Pages/UICrafterPage.razor
@@ -1,7 +1,7 @@
 @page "/uicrafter"
 @attribute [Authorize]
 
-<MudStack Row="true" @onclick="OnBackgroundClick" Style="height: 100vh;">
+<MudStack Row @onclick="OnBackgroundClick" Style="height: 100vh;">
     <!-- Left section: Component Grid (20%) -->
     <MudStack Style="width: 20%">
         <MudText Class="">Components:</MudText>
@@ -16,7 +16,13 @@
 
     <!-- Right section: Component Properties (25%) -->
     <MudStack Style="width: 25%;">
-        <MudText>Properties:</MudText>
+        <MudStack Row>
+            <MudText>@($"{CurrentPropertiesName()} properties:")</MudText>
+            @if (SelectedComponent is not null)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="() => {SelectedComponent = null;}" Class="ml-auto mud-background-gray" Size="Size.Small" Variant="Variant.Filled"/>
+            }
+        </MudStack>
         <Properties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" @bind-AppView="AppView"/>
     </MudStack>
 </MudStack>
@@ -35,4 +41,12 @@
         SelectedComponent = null;
         DropContainer?.Refresh();
     }
+
+    private string CurrentPropertiesName() => SelectedComponent?.ComponentCase switch
+    {
+        UIComponent.ComponentOneofCase.Button => "API-Button",
+        UIComponent.ComponentOneofCase.InputField => "Input Field",
+        UIComponent.ComponentOneofCase.Textbox => "Textbox",
+        _ => "App-view",
+    };
 }

--- a/src/UICrafter.Client/Pages/UICrafterPage.razor
+++ b/src/UICrafter.Client/Pages/UICrafterPage.razor
@@ -1,7 +1,7 @@
 @page "/uicrafter"
 @attribute [Authorize]
 
-<MudStack Row="true">
+<MudStack Row="true" @onclick="() => {SelectedComponent = null;}">
     <!-- Left section: Component Grid (20%) -->
     <ComponentGrid @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
 
@@ -15,7 +15,18 @@
     </MudStack>
 
     <!-- Right section: Component Properties (25%) -->
-    <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
+    <MudStack Style="width: 25%;" @onclick:stopPropagation>
+        <MudText>Properties:</MudText>
+        @if (SelectedComponent is not null)
+        {
+            <ComponentProperties @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponents="@UIComponentList.UIComponents" />
+        }
+        else
+        {
+            <MudText>AppView properties and buttons</MudText>
+            @* <AppViewButtons @bind-SelectedComponent="@SelectedComponent" @bind-DropContainer="@DropContainer" UIComponentList="@UIComponentList" /> *@
+        }
+    </MudStack>
 </MudStack>
 
 

--- a/src/UICrafter.Mobile/wwwroot/index.html
+++ b/src/UICrafter.Mobile/wwwroot/index.html
@@ -6,10 +6,10 @@
 	<title>UICrafter.Mobile</title>
 	<base href="/" />
 	<link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
-	<link rel="stylesheet" href="css/app.css" />
 	<link rel="stylesheet" href="UICrafter.Mobile.styles.css" />
 	<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
 	<link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+	<link rel="stylesheet" href="css/app.css" />
 	<link rel="icon" type="image/png" href="favicon.png" />
 </head>
 

--- a/src/UICrafter/wwwroot/app.css
+++ b/src/UICrafter/wwwroot/app.css
@@ -1,6 +1,21 @@
 body {
 }
 
+/* Custom css to avoid tooltip offsetting the button group */
 .uicrafter-tooltip-buttongroup > .mud-tooltip-root {
-	display: inline-flex !important;
+	display: inline-flex;
+}
+
+/* Custom css to align switch left despite LabelPosition = start */
+.uicrafter-switch .mud-switch.flex-row-reverse {
+	display: flex;
+	flex-direction: row-reverse;
+	justify-content: flex-end;
+	margin-left: unset;
+}
+
+/* Custom css to make the switch-track changed color when its active */
+/* Style utilizes that .mud-switch-base gains .mud-checked when its toggled on */
+.uicrafter-switch .mud-switch-base.mud-checked + .mud-switch-track {
+	background-color: var(--mud-palette-primary);
 }


### PR DESCRIPTION
Made changes to the layout of UICrafter page
Updated some functionality in connection with the layout update
- Editing and viewing AppView data in properties section
- Removed save button for components in properties section
- Now re-renders when you click the background